### PR TITLE
fix: 상품 상세 정보 조회 시 오류 수정

### DIFF
--- a/src/main/java/com/pickx3/service/WorkService.java
+++ b/src/main/java/com/pickx3/service/WorkService.java
@@ -74,8 +74,6 @@ public class WorkService {
         Work work = workRepository.findById(workNum).get();
         List<WorkImgForm> workImages = workImgRepository.findByWork_workNum(workNum);
 
-        log.info("상품 이미지 정보" + workImages.get(0).getWorkImgName());
-
         WorkDetailDTO workDetailDTO = new WorkDetailDTO();
         workDetailDTO.setWorkNum(work.getWorkNum());
         workDetailDTO.setWorkerNum(work.getUserInfo().getId());


### PR DESCRIPTION
- 문제
상품 이미지가 없을 경우 Index 0 out of bounds for length 0 오류 발생

- 해결
상품 이미지 배열 0번째 데이터를 확인 하는 코드 삭제 => 이미지가 없는데 0번째 데이터를 가져오려고 해서 오류 발생했음