### PR TITLE
feat : 태그 이름들로 포트폴리오 검색하는 api 추가

### DIFF
--- a/src/main/java/com/pickx3/controller/PortfolioController.java
+++ b/src/main/java/com/pickx3/controller/PortfolioController.java
@@ -5,8 +5,10 @@ import com.pickx3.domain.entity.portfolio_package.PortfolioForm;
 import com.pickx3.domain.entity.portfolio_package.PortfolioImg;
 import com.pickx3.domain.entity.portfolio_package.dto.PortfolioResponseDto;
 import com.pickx3.domain.entity.portfolio_package.dto.TagRequestDto;
+import com.pickx3.domain.repository.PortfolioRepository;
 import com.pickx3.service.PortfolioImgService;
 import com.pickx3.service.PortfolioService;
+import com.pickx3.service.TagService;
 import com.pickx3.util.rsMessage;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,9 @@ import java.util.*;
 public class PortfolioController {
     private final PortfolioService portfolioService;
     private final PortfolioImgService portfolioImgService;
+
+    private final PortfolioRepository portfolioRepository;
+    private final TagService tagService;
 
 
     /**
@@ -110,6 +115,18 @@ public class PortfolioController {
 
         return getResponseEntity(data);
     }
+
+    @Operation(summary = "태그들에 따른 포폴 목록 조회" , description = "")
+    @GetMapping("/portfolio/list/tags")
+    public ResponseEntity<?> tag_list(String tags){
+        List<PortfolioResponseDto> data = tagService.portfolioSearchByTags(tags);
+//        List<Portfolio> portfolios = portfolioRepository.findAllById(pofoNum);
+        return getResponseEntity(data);
+    }
+
+
+
+
 
 
     /**

--- a/src/main/java/com/pickx3/domain/repository/PortfolioTagRepository.java
+++ b/src/main/java/com/pickx3/domain/repository/PortfolioTagRepository.java
@@ -1,11 +1,14 @@
-package com.pickx3.domain.repository.post_package;
+package com.pickx3.domain.repository;
 
 import com.pickx3.domain.entity.portfolio_package.PortfolioTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface PortfolioTagRepository extends JpaRepository<PortfolioTag, Long> {
 
    // Set<PortfolioTag> findByPortfolio_id(Long id);
 
    // PortfolioTag findByPortfolio_PortfolioName(String name);
+   List<PortfolioTag> findByTag_tagNum(Long tagNum);
 }

--- a/src/main/java/com/pickx3/domain/repository/TagRepository.java
+++ b/src/main/java/com/pickx3/domain/repository/TagRepository.java
@@ -3,9 +3,13 @@ package com.pickx3.domain.repository;
 import com.pickx3.domain.entity.portfolio_package.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
    // Set<Tag> findByPortfolioTag_id(String name);
+
+    List<Tag> findByTagName(String tagName);
 
 
 }

--- a/src/main/java/com/pickx3/service/PortfolioService.java
+++ b/src/main/java/com/pickx3/service/PortfolioService.java
@@ -11,7 +11,7 @@ import com.pickx3.domain.entity.user_package.User;
 import com.pickx3.domain.repository.PortfolioRepository;
 import com.pickx3.domain.repository.TagRepository;
 import com.pickx3.domain.repository.UserRepository;
-import com.pickx3.domain.repository.post_package.PortfolioTagRepository;
+import com.pickx3.domain.repository.PortfolioTagRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -117,6 +117,7 @@ public class PortfolioService {
 
         return portfolioResponseDtos;
     }
+
 
 
 }

--- a/src/main/java/com/pickx3/service/TagService.java
+++ b/src/main/java/com/pickx3/service/TagService.java
@@ -1,15 +1,59 @@
 package com.pickx3.service;
 
+import com.pickx3.domain.entity.portfolio_package.PortfolioTag;
+import com.pickx3.domain.entity.portfolio_package.Tag;
+import com.pickx3.domain.entity.portfolio_package.dto.PortfolioResponseDto;
+import com.pickx3.domain.repository.PortfolioRepository;
+import com.pickx3.domain.repository.TagRepository;
+import com.pickx3.domain.repository.UserRepository;
+import com.pickx3.domain.repository.PortfolioTagRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j @Transactional
 @RequiredArgsConstructor
 @Service
 public class TagService {
+
+    private final PortfolioRepository portfolioRepository;
+    private final PortfolioTagRepository portfolioTagRepository;
+    private final UserRepository userRepository;
+    private final TagRepository tagRepository;
+
+    public List<PortfolioResponseDto> portfolioSearchByTags(String tags) {
+        String[] tagArray = tags.split(" ");
+        List<Long> tagNumList = new ArrayList<>();
+        List<Long> pofoNumList = new ArrayList<>();
+
+        for(String t : tagArray){
+            List<Tag> temp = tagRepository.findByTagName(t);
+            for(Tag t1 : temp){
+                tagNumList.add(t1.getTagNum());
+            }
+        }
+
+        for(Long t :tagNumList){
+            List<PortfolioTag> pf = portfolioTagRepository.findByTag_tagNum(t);
+            for(PortfolioTag p : pf){
+                pofoNumList.add(p.getPortfolio().getPortfolioNum());
+            }
+        }
+
+        List<Long> newList = pofoNumList.stream().distinct().collect(Collectors.toList());
+        List<PortfolioResponseDto> portfolioResponseDtos = new ArrayList<>();
+        for(Long l : newList){
+            portfolioResponseDtos.add(new PortfolioResponseDto(portfolioRepository.findById(l).get()));
+        }
+
+        return portfolioResponseDtos;
+    }
+
 
 
 }


### PR DESCRIPTION
- 구분자 띄어쓰기로 태그이름들 작성해서 보내주면 그 태그 갖고 있는 포트폴리오들 출력