### PR TITLE
fix : 리액트 연동 시 결제 정보 검증하는 파라미터 값을 못 받는 오류 발생

### DIFF
--- a/src/main/java/com/pickx3/controller/PaymentController.java
+++ b/src/main/java/com/pickx3/controller/PaymentController.java
@@ -26,14 +26,10 @@ public class PaymentController {
     private PaymentService payService;
 
     @PostMapping("/verify")
-    public ResponseEntity<?>  verifyPayment(String imp_uid, String merchant_uid, Model model) throws Exception {
+    public ResponseEntity<?>  verifyPayment(@RequestBody VerifyDTO verifyDTO, Model model) throws Exception {
         ApiResponseMessage result;
         HashMap data = new HashMap<>();
 
-        VerifyDTO verifyDTO = VerifyDTO.builder()
-                .imp_uid(imp_uid)
-                .merchantUid(merchant_uid)
-                .build();
         log.info("여기로 들어오는지" + verifyDTO.getImp_uid());
         log.info("여기로 들어오는지" + verifyDTO.getMerchantUid());
 


### PR DESCRIPTION
- Controller쪽에서 데이터를 못받아서 오류가 발생
- @RequestBody을 선언 후 파라미터 타입을 verfifyDTO로 변경